### PR TITLE
fix(shell): overwrite /etc/hosts

### DIFF
--- a/pkg/embed/shell/30-etc-hosts.sh
+++ b/pkg/embed/shell/30-etc-hosts.sh
@@ -38,7 +38,7 @@ if [[ $modified == "true" ]]; then
       "Start-Process -Verb runAs powershell.exe -ArgumentList '-c Move-Item -Force -Path \"$(wslpath -w "$tempFile")\" -Destination \"$(wslpath -w "$hostsFile")\"'"
   else
     echo "Updating $hostsFile, password prompt (if present) is for sudo access"
-    sudo cp "$tempFile" "$hostsFile"
+    yes | sudo cp -f "$tempFile" "$hostsFile"
     rm "$tempFile" >/dev/null 2>&1 || true
   fi
 fi


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->
<!-- 
  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: This PR fixes the new `cp` usage to properly overwrite the existing `/etc/hosts`. I use `yes` piped into `cp` in case the shell is interactive, since we could be using busybox or regular POSIX `cp`. 

<!--- Block(jiraPrefix) --->
**JIRA ID**: DT-0
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
