### PR TITLE
fix: append only to /etc/hosts in CI

### DIFF
--- a/pkg/embed/shell/30-etc-hosts.sh
+++ b/pkg/embed/shell/30-etc-hosts.sh
@@ -16,9 +16,14 @@ if [[ $OS == "windows" ]]; then
   hostsFile="/mnt/c/Windows/System32/drivers/etc/hosts"
 fi
 
-tempFile=$(mktemp)
-
-cp "$hostsFile" "$tempFile"
+# We can't modify the file in Docker, which we use in CI, so for now
+# just write to that w/o the one-time sudo optimization.
+if [[ -z $CI ]]; then
+  cp "$hostsFile" "$tempFile"
+  tempFile=$(mktemp)
+else
+  tempFile="$hostsFile"
+fi
 
 modified=false
 for domain in "${domains[@]}"; do
@@ -30,7 +35,7 @@ for domain in "${domains[@]}"; do
 done
 
 # Only replace the file when it's been updated.
-if [[ $modified == "true" ]]; then
+if [[ $modified == "true" ]] && [[ -z $CI ]]; then
   # To minimize the number of sudo / UAC calls we have to
   # move the hosts file to replace the existing one
   if [[ $OS == "windows" ]]; then
@@ -38,7 +43,7 @@ if [[ $modified == "true" ]]; then
       "Start-Process -Verb runAs powershell.exe -ArgumentList '-c Move-Item -Force -Path \"$(wslpath -w "$tempFile")\" -Destination \"$(wslpath -w "$hostsFile")\"'"
   else
     echo "Updating $hostsFile, password prompt (if present) is for sudo access"
-    yes | sudo cp -f "$tempFile" "$hostsFile"
+    sudo mv "$tempFile" "$hostsFile"
     rm "$tempFile" >/dev/null 2>&1 || true
   fi
 fi

--- a/pkg/embed/shell/30-etc-hosts.sh
+++ b/pkg/embed/shell/30-etc-hosts.sh
@@ -29,7 +29,11 @@ modified=false
 for domain in "${domains[@]}"; do
   if ! grep "$domain" "$hostsFile" >/dev/null 2>&1; then
     echo " ADD $domain"
-    echo "127.0.0.1 $domain" >>"$tempFile"
+    if [[ -z $CI ]]; then
+      echo "127.0.0.1 $domain" >>"$tempFile"
+    else
+      sudo bash -c "echo '127.0.0.1 $domain' >>'$tempFile'"
+    fi
     modified=true
   fi
 done


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->
<!-- 
  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: This PR changes the behaviour of the `/etc/hosts` modifier in CI, when being ran in a docker container we can't remove `/etc/hosts` because it's being controlled by the docker daemon via a volume mount, but we can append. So, we use the old behaviour of appending to the live /etc/hosts in CI, and do the one-time move logic otherwise (saves on sudo calls) 

<!--- Block(jiraPrefix) --->
**JIRA ID**: [DT-494]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:


[DT-494]: https://outreach-io.atlassian.net/browse/DT-494