### PR TITLE
fix: copy /etc/hosts properly

### DIFF
--- a/pkg/embed/shell/30-etc-hosts.sh
+++ b/pkg/embed/shell/30-etc-hosts.sh
@@ -19,8 +19,8 @@ fi
 # We can't modify the file in Docker, which we use in CI, so for now
 # just write to that w/o the one-time sudo optimization.
 if [[ -z $CI ]]; then
-  cp "$hostsFile" "$tempFile"
   tempFile=$(mktemp)
+  cp "$hostsFile" "$tempFile"
 else
   tempFile="$hostsFile"
 fi


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->
<!-- 
  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: This PR fixes the non-CI `/etc/hosts` behaviour to properly copy to a temp file. 

<!--- Block(jiraPrefix) --->
**JIRA ID**: DT-0
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**: [**CONTEXT**](https://outreach-hq.slack.com/archives/CN9MU7GLW/p1623881407189600)
