### PR TITLE
feat: remove docker box :latest images on provision

### DIFF
--- a/cmd/devenv/devenv.go
+++ b/cmd/devenv/devenv.go
@@ -188,6 +188,7 @@ func main() { //nolint:funlen
 		snapshot.NewCmdSnapshot(log),
 		expose.NewCmdExpose(log),
 		{
+			// DEPRECATED: Remove on the next minor release, was undocumented
 			Name:   "remove-image",
 			Hidden: true,
 			Action: func(c *cli.Context) error {

--- a/cmd/devenv/provision/provision.go
+++ b/cmd/devenv/provision/provision.go
@@ -439,6 +439,7 @@ func (o *Options) createKindCluster(ctx context.Context) error {
 }
 
 func (o *Options) removeServiceImages(ctx context.Context) error {
+	//nolint:gosec // Why: We're passing a constant
 	cmd := exec.CommandContext(ctx, "docker", "exec", "-it",
 		kubernetesruntime.KindClusterName+"-control-plane", "ctr", "--namespace", "k8s.io", "images", "ls")
 	b, err := cmd.CombinedOutput()
@@ -539,6 +540,7 @@ func (o *Options) Run(ctx context.Context) error { //nolint:funlen,gocyclo
 		return errors.Wrap(err, "failed to ensure snapshot storage exists")
 	}
 
+	//nolint:govet // Why: OK w/ err shadow
 	if err := o.removeServiceImages(ctx); err != nil {
 		return errors.Wrap(err, "failed to remove docker images from cache")
 	}

--- a/cmd/devenv/provision/provision.go
+++ b/cmd/devenv/provision/provision.go
@@ -1,6 +1,8 @@
 package provision
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/base64"
@@ -25,6 +27,7 @@ import (
 	"github.com/getoutreach/devenv/pkg/aws"
 	"github.com/getoutreach/devenv/pkg/box"
 	"github.com/getoutreach/devenv/pkg/cmdutil"
+	"github.com/getoutreach/devenv/pkg/containerruntime"
 	"github.com/getoutreach/devenv/pkg/devenvutil"
 	"github.com/getoutreach/devenv/pkg/kube"
 	"github.com/getoutreach/devenv/pkg/kubernetesruntime"
@@ -435,6 +438,45 @@ func (o *Options) createKindCluster(ctx context.Context) error {
 	return kubernetesruntime.InitKind(ctx, o.log)
 }
 
+func (o *Options) removeServiceImages(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "docker", "exec", "-it",
+		kubernetesruntime.KindClusterName+"-control-plane", "ctr", "--namespace", "k8s.io", "images", "ls")
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		return err
+	}
+
+	images := make(map[string]bool)
+	scanner := bufio.NewScanner(bytes.NewReader(b))
+	for scanner.Scan() {
+		text := scanner.Text()
+
+		split := strings.Split(text, " ")
+		if len(split) < 1 {
+			continue
+		}
+
+		img := split[0]
+		if !strings.HasPrefix(img, o.b.DeveloperEnvironmentConfig.ImageRegistry) {
+			continue
+		}
+
+		if !strings.HasSuffix(img, ":latest") {
+			continue
+		}
+
+		images[img] = true
+	}
+
+	for img := range images {
+		if err2 := containerruntime.RemoveImage(ctx, img); err2 != nil {
+			o.log.WithField("image", img).Warn("Failed to remove docker image")
+		}
+	}
+
+	return nil
+}
+
 // generateDockerConfig generates a docker configuration file that is used
 // to authenticate image pulls by KinD
 func (o *Options) generateDockerConfig() error {
@@ -497,8 +539,9 @@ func (o *Options) Run(ctx context.Context) error { //nolint:funlen,gocyclo
 		return errors.Wrap(err, "failed to ensure snapshot storage exists")
 	}
 
-	// TODO: update all the docker images
-	// this can probably be done post-mvp
+	if err := o.removeServiceImages(ctx); err != nil {
+		return errors.Wrap(err, "failed to remove docker images from cache")
+	}
 
 	if !o.Base {
 		// Restore using a snapshot


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->
<!-- 
  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: This PR adds automatic removal of `:latest` docker images on the configured `box` image registry on `devenv provision`. This was in the OG devenv as users seemed to expect this behaviour, it was slated to be added back post-MVP. So, this adds it back (now in Go!)

<!--- Block(jiraPrefix) --->
**JIRA ID**: DT-0
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
