### PR TITLE
fix: use readwrite aws role by default

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -33,7 +33,7 @@ func DefaultCredentialOptions() *CredentialOptions {
 	}
 
 	return &CredentialOptions{
-		Role:    "arn:aws:iam::182192988802:role/okta_eng_readonly_role",
+		Role:    "arn:aws:iam::182192988802:role/okta_eng_readwrite_role",
 		Profile: profile,
 	}
 }

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -14,9 +14,9 @@ func Test_assumedToRole(t *testing.T) {
 		{
 			name: "should properly parse principal_arn",
 			args: args{
-				assumedRole: "arn:aws:sts::182192988802:assumed-role/okta_eng_readonly_role/jared.allard@outreach.io",
+				assumedRole: "arn:aws:sts::182192988802:assumed-role/okta_eng_readwrite_role/jared.allard@outreach.io",
 			},
-			want: "arn:aws:iam::182192988802:role/okta_eng_readonly_role",
+			want: "arn:aws:iam::182192988802:role/okta_eng_readwrite_role",
 		},
 		{
 			name: "should ignore invalid input",


### PR DESCRIPTION
This affects the default AWS role selected when using `orc setup`. We
need the default role to be readwrite in the dev environment because
write access is needed for voice scenarios involving the use of
secretsmanager as a security-compliant cache.

<!-- !!!! README !!!! Please fill this out. -->
<!-- 
  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: 

<!--- Block(jiraPrefix) --->
**JIRA ID**: XX-XX
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
