### PR TITLE
fix: remove TTY argument in remove images

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.16
+golang 1.16.5
 terraform 0.14.7
 ###Block(toolver)
 ###EndBlock(toolver)

--- a/cmd/devenv/provision/provision.go
+++ b/cmd/devenv/provision/provision.go
@@ -440,11 +440,11 @@ func (o *Options) createKindCluster(ctx context.Context) error {
 
 func (o *Options) removeServiceImages(ctx context.Context) error {
 	//nolint:gosec // Why: We're passing a constant
-	cmd := exec.CommandContext(ctx, "docker", "exec", "-it",
+	cmd := exec.CommandContext(ctx, "docker", "exec",
 		kubernetesruntime.KindClusterName+"-control-plane", "ctr", "--namespace", "k8s.io", "images", "ls")
 	b, err := cmd.CombinedOutput()
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to list docker images: %s", string(b))
 	}
 
 	images := make(map[string]bool)
@@ -470,6 +470,7 @@ func (o *Options) removeServiceImages(ctx context.Context) error {
 	}
 
 	for img := range images {
+		o.log.WithField("image", img).Infoln("Removing docker image")
 		if err2 := containerruntime.RemoveImage(ctx, img); err2 != nil {
 			o.log.WithField("image", img).Warn("Failed to remove docker image")
 		}

--- a/pkg/embed/config/kind.yaml
+++ b/pkg/embed/config/kind.yaml
@@ -3,7 +3,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: "{{ .Name }}"
 nodes:
   - role: control-plane
-    image: "gcr.io/outreach-docker/kindest/node:v1.20.5{{ .TagSuffix }}"
+    image: "gcr.io/outreach-docker/kindest/node:v1.20.7"
     extraMounts:
       - containerPath: /var/lib/kubelet/config.json
         readOnly: true


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->
<!-- 
  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: This PR removes the `-it` (interactive, tty) request to the `docker exec` call for removing docker images. This would sometimes trip up and cause the command to fail. 

<!--- Block(jiraPrefix) --->
**JIRA ID**: DT-0
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**: [**Context**](https://outreach-hq.slack.com/archives/CN9MU7GLW/p1625079167475400)
