### PR TITLE
fix: update gobox to include ssh agent enhancements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containerd/containerd v1.4.4 // indirect
 	github.com/docker/docker v20.10.5+incompatible
 	github.com/docker/go-connections v0.4.0
-	github.com/getoutreach/gobox v1.0.1
+	github.com/getoutreach/gobox v1.4.0
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.1
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/function61/gokit v0.0.0-20201222133023-aeb11a5badac/go.mod h1:zoPwlTF/LeWbdcLYJbaZdHiXAbhhQnaDP336tJ4uG3o=
 github.com/fvbommel/sortorder v1.0.1 h1:dSnXLt4mJYH25uDDGa3biZNQsozaUWDSWeKJ0qqFfzE=
 github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
-github.com/getoutreach/gobox v1.0.1 h1:12g1rhaQo+k5rVkj8eIgS/Gm7DoNNE9YdWRQZiX1hqM=
-github.com/getoutreach/gobox v1.0.1/go.mod h1:DlhTg8sNywKYWrGy7sbwhez0EqamRHfBeH7ywvJNTHw=
+github.com/getoutreach/gobox v1.4.0 h1:UmPAXEmiDMb7xpaqy3476AV4U+cZ+Yrruek3o19HKEc=
+github.com/getoutreach/gobox v1.4.0/go.mod h1:DlhTg8sNywKYWrGy7sbwhez0EqamRHfBeH7ywvJNTHw=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->
<!--
  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**:

Brings in changes from (below pr) to allow `devenv` to leverage
existing ssh agents when running (no more entering your passphrase every
time!)
https://github.com/getoutreach/gobox/pull/24


<!--- Block(jiraPrefix) --->
**JIRA ID**: noop
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**: