### PR TITLE
docs(README): remove base reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ xattr -c $(command -v devenv)
 To create a developer environment, run:
 
 ```bash
-devenv provision --base
+devenv provision
 ```
 
 Next there's a manual step that you'll need to do. You'll need to add a `KUBECONFIG` environment variable, this can be done by adding the line below to your shellrc (generally `~/.zshrc` or `~/.zsh_profile` or `~/.bashrc`):


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->
<!-- 
  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: This PR removes the reference to `--base`, while this is correct for OSS users to use, for Outreach (and people w/ Box configuration) this is not the correct flag.

We'll be revamping this later w/ Bootstrap OSS anyways, so for now let's stop people from hurting themselves.

<!--- Block(jiraPrefix) --->
**JIRA ID**: DT-0
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
