### PR TITLE
feat: support channels / history of snapshots

### DIFF
--- a/cmd/devenv/provision/provision.go
+++ b/cmd/devenv/provision/provision.go
@@ -78,9 +78,10 @@ var (
 )
 
 type Options struct {
-	DeployApps     []string
-	SnapshotTarget string
-	Base           bool
+	DeployApps      []string
+	SnapshotTarget  string
+	SnapshotChannel box.SnapshotLockChannel
+	Base            bool
 
 	log     logrus.FieldLogger
 	d       dockerclient.APIClient
@@ -138,6 +139,11 @@ func NewCmdProvision(log logrus.FieldLogger) *cli.Command { //nolint:funlen
 				Usage: "Snapshot target to use",
 				Value: defaultSnapshot,
 			},
+			&cli.StringFlag{
+				Name:  "snapshot-channel",
+				Usage: "Snapshot channel to use",
+				Value: string(box.SnapshotLockChannelStable),
+			},
 		},
 		Action: func(c *cli.Context) error {
 			o, err := NewOptions(log)
@@ -149,6 +155,7 @@ func NewCmdProvision(log logrus.FieldLogger) *cli.Command { //nolint:funlen
 
 			o.Base = c.Bool("base")
 			o.SnapshotTarget = c.String("snapshot-target")
+			o.SnapshotChannel = box.SnapshotLockChannel(c.String("snapshot-channel"))
 
 			return o.Run(c.Context)
 		},

--- a/cmd/devenv/snapshot/snapshot.go
+++ b/cmd/devenv/snapshot/snapshot.go
@@ -168,6 +168,11 @@ func NewCmdSnapshot(log logrus.FieldLogger) *cli.Command { //nolint:funlen
 						Name:  "skip-upload",
 						Usage: "Generate a snapshot, but don't upload it",
 					},
+					&cli.StringFlag{
+						Name:  "channel",
+						Value: string(box.SnapshotLockChannelRC),
+						Usage: "Which channel this snapshot should be uploaded to",
+					},
 				},
 				Action: func(c *cli.Context) error {
 					b, err := ioutil.ReadFile("snapshots.yaml")
@@ -181,7 +186,7 @@ func NewCmdSnapshot(log logrus.FieldLogger) *cli.Command { //nolint:funlen
 						return err
 					}
 
-					return o.Generate(c.Context, s, c.Bool("skip-upload"))
+					return o.Generate(c.Context, s, c.Bool("skip-upload"), box.SnapshotLockChannel(c.String("channel")))
 				},
 			},
 		},

--- a/cmd/devenv/snapshot/snapshot_generate.go
+++ b/cmd/devenv/snapshot/snapshot_generate.go
@@ -28,7 +28,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func (o *Options) Generate(ctx context.Context, s *box.SnapshotGenerateConfig, skipUpload bool) error { //nolint:funlen
+func (o *Options) Generate(ctx context.Context, s *box.SnapshotGenerateConfig, skipUpload bool, channel box.SnapshotLockChannel) error { //nolint:funlen
 	b, err := box.LoadBox()
 	if err != nil {
 		return errors.Wrap(err, "failed to load box configuration")
@@ -44,7 +44,6 @@ func (o *Options) Generate(ctx context.Context, s *box.SnapshotGenerateConfig, s
 		return err
 	}
 
-	// TODO: We need to allow this to be changed
 	copts := devenvaws.DefaultCredentialOptions()
 	if b.DeveloperEnvironmentConfig.SnapshotConfig.WriteAWSRole != "" {
 		copts.Role = b.DeveloperEnvironmentConfig.SnapshotConfig.WriteAWSRole
@@ -52,7 +51,7 @@ func (o *Options) Generate(ctx context.Context, s *box.SnapshotGenerateConfig, s
 	copts.Log = o.log
 	err = devenvaws.EnsureValidCredentials(ctx, copts)
 	if err != nil {
-		return errors.Wrap(err, "failed to get neccesssary permissions")
+		return errors.Wrap(err, "failed to get necessary permissions")
 	}
 
 	cfg, err := config.LoadDefaultConfig(ctx)
@@ -63,14 +62,41 @@ func (o *Options) Generate(ctx context.Context, s *box.SnapshotGenerateConfig, s
 
 	s3c := s3.NewFromConfig(cfg)
 
-	generatedTargets := make(map[string]*box.SnapshotLockTarget)
+	lockfile := &box.SnapshotLock{}
+	resp, err := s3c.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: &b.DeveloperEnvironmentConfig.SnapshotConfig.Bucket,
+		Key:    aws.String("automated-snapshots/v2/latest.yaml"),
+	})
+	if err == nil {
+		defer resp.Body.Close()
+		err = yaml.NewDecoder(resp.Body).Decode(&lockfile)
+		if err != nil {
+			return errors.Wrap(err, "failed to parse remote snapshot lockfile")
+		}
+	} else {
+		o.log.WithError(err).
+			Warn("Failed to fetch existing remote snapshot lockfile, will generate a new one")
+	}
+
 	for name, t := range s.Targets {
 		//nolint:govet // Why: We're OK shadowing err
-		var err error
-		generatedTargets[name], err = o.generateSnapshot(ctx, mc, s3c, name, t, skipUpload)
+		itm, err := o.generateSnapshot(ctx, mc, s3c, name, t, skipUpload)
 		if err != nil {
 			return err
 		}
+
+		if _, ok := lockfile.TargetsV2[name]; !ok {
+			lockfile.TargetsV2[name] = &box.SnapshotLockList{}
+		}
+
+		if _, ok := lockfile.TargetsV2[name].Snapshots[channel]; !ok {
+			lockfile.TargetsV2[name].Snapshots[channel] = make([]*box.SnapshotLockListItem, 0)
+		}
+
+		// Make this the latest version
+		lockfile.TargetsV2[name].Snapshots[channel] = append(
+			[]*box.SnapshotLockListItem{itm}, lockfile.TargetsV2[name].Snapshots[channel]...,
+		)
 	}
 
 	// Don't generate a lock if we're not uploading
@@ -78,13 +104,9 @@ func (o *Options) Generate(ctx context.Context, s *box.SnapshotGenerateConfig, s
 		return nil
 	}
 
-	lock := &box.SnapshotLock{
-		Version:     1,
-		GeneratedAt: time.Now().UTC(),
-		Targets:     generatedTargets,
-	}
+	lockfile.GeneratedAt = time.Now().UTC()
 
-	byt, err := yaml.Marshal(lock)
+	byt, err := yaml.Marshal(lockfile)
 	if err != nil {
 		return err
 	}
@@ -204,7 +226,7 @@ func (o *Options) uploadSnapshot(ctx context.Context, mc *minio.Client, s3c *s3.
 
 //nolint:funlen
 func (o *Options) generateSnapshot(ctx context.Context, mc *minio.Client, s3c *s3.Client,
-	name string, t *box.SnapshotTarget, skipUpload bool) (*box.SnapshotLockTarget, error) {
+	name string, t *box.SnapshotTarget, skipUpload bool) (*box.SnapshotLockListItem, error) {
 	o.log.WithField("snapshot", name).Info("Generating Snapshot")
 
 	destroyOpts, err := destroy.NewOptions(o.log)
@@ -269,7 +291,7 @@ func (o *Options) generateSnapshot(ctx context.Context, mc *minio.Client, s3c *s
 		}
 	}
 
-	return &box.SnapshotLockTarget{
+	return &box.SnapshotLockListItem{
 		Digest:           hash,
 		URI:              key,
 		Config:           t,

--- a/cmd/devenv/snapshot/snapshot_generate.go
+++ b/cmd/devenv/snapshot/snapshot_generate.go
@@ -78,6 +78,10 @@ func (o *Options) Generate(ctx context.Context, s *box.SnapshotGenerateConfig, s
 			Warn("Failed to fetch existing remote snapshot lockfile, will generate a new one")
 	}
 
+	if lockfile.TargetsV2 == nil {
+		lockfile.TargetsV2 = make(map[string]*box.SnapshotLockList)
+	}
+
 	for name, t := range s.Targets {
 		//nolint:govet // Why: We're OK shadowing err
 		itm, err := o.generateSnapshot(ctx, mc, s3c, name, t, skipUpload)
@@ -87,6 +91,10 @@ func (o *Options) Generate(ctx context.Context, s *box.SnapshotGenerateConfig, s
 
 		if _, ok := lockfile.TargetsV2[name]; !ok {
 			lockfile.TargetsV2[name] = &box.SnapshotLockList{}
+		}
+
+		if lockfile.TargetsV2[name].Snapshots == nil {
+			lockfile.TargetsV2[name].Snapshots = make(map[box.SnapshotLockChannel][]*box.SnapshotLockListItem)
 		}
 
 		if _, ok := lockfile.TargetsV2[name].Snapshots[channel]; !ok {

--- a/pkg/box/box.go
+++ b/pkg/box/box.go
@@ -2,6 +2,13 @@ package box
 
 import "time"
 
+type SnapshotLockChannel string
+
+const (
+	SnapshotLockChannelStable SnapshotLockChannel = "stable"
+	SnapshotLockChannelRC     SnapshotLockChannel = "rc"
+)
+
 type DeveloperEnvironmentConfig struct {
 	// SnapshotConfig is the snapshot configuration for the devenv
 	SnapshotConfig *SnapshotConfig `yaml:"snapshots"`
@@ -118,9 +125,31 @@ type SnapshotLockTarget struct {
 	VeleroBackupName string `yaml:"veleroBackupName"`
 }
 
+type SnapshotLockListItem struct {
+	// Digest is a MD5 base64 encoded digest of the archive
+	Digest string `yaml:"digest"`
+
+	// Key is the key that this snapshot is stored at, note that the bucket is
+	// not set or determined here and instead come from the snapshotconfig
+	URI string `yaml:"key"`
+
+	// Config is the config used to generate this snapshot
+	Config *SnapshotTarget
+
+	// VeleroBackupName is the name of this snapshot. This is used to invoke velero
+	// commands. It should not be used for uniqueness constraints.
+	VeleroBackupName string `yaml:"veleroBackupName"`
+}
+type SnapshotLockList struct {
+	// Snapshots is a channel seperated list of snapshots for a given target
+	Snapshots map[SnapshotLockChannel][]*SnapshotLockListItem `yaml:"snapshots"`
+}
+
 // SnapshotLock is an manifest of all the available snapshots
 type SnapshotLock struct {
 	Version     int                            `yaml:"version"`
 	GeneratedAt time.Time                      `yaml:"generatedAt"`
 	Targets     map[string]*SnapshotLockTarget `yaml:"targets"`
+
+	TargetsV2 map[string]*SnapshotLockList `yaml:"targets_v2"`
 }

--- a/pkg/box/box.go
+++ b/pkg/box/box.go
@@ -141,7 +141,7 @@ type SnapshotLockListItem struct {
 	VeleroBackupName string `yaml:"veleroBackupName"`
 }
 type SnapshotLockList struct {
-	// Snapshots is a channel seperated list of snapshots for a given target
+	// Snapshots is a channel separated list of snapshots for a given target
 	Snapshots map[SnapshotLockChannel][]*SnapshotLockListItem `yaml:"snapshots"`
 }
 


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->
<!-- 
  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: This PR adds support for two different channels: `stable` and `rc`. These can be used to test different snapshot versions. The new lock format also stores snapshots as new ones are added, this can be used, eventually, to allow older snapshots to be re-used in the case of problems.

<!--- Block(jiraPrefix) --->
**JIRA ID**: XX-XX
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:
