### PR TITLE
fix(kubectly): pass correct args to kubectl

### DIFF
--- a/cmd/devenv/kubectl/kubectl.go
+++ b/cmd/devenv/kubectl/kubectl.go
@@ -3,7 +3,6 @@ package kubectl
 import (
 	"context"
 	"math/rand"
-	"os"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -43,7 +42,7 @@ func (o *Options) Run(ctx context.Context) error {
 	rand.Seed(time.Now().UnixNano())
 
 	command := cmd.NewDefaultKubectlCommand()
-	command.SetArgs(append([]string{"--context", "dev-environment"}, os.Args[2:]...))
+	command.SetArgs(append([]string{"--context", "dev-environment"}, o.Args...))
 
 	logs.InitLogs()
 	defer logs.FlushLogs()


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->
<!-- 
  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: This PR fixes `kubectl` to not choke on `--skip-update`, or other devenv specific flags, by using only args after `devenv kubectl`. Unsure why I didn't do this in the first place. 

<!--- Block(jiraPrefix) --->
**JIRA ID**: [DTSS-0]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:

<!--- Block(custom) -->
<!--- EndBlock(custom) -->
