### PR TITLE
feat(deploy-app): wait for pods to be ready after deploy

### DIFF
--- a/pkg/app/deploy.go
+++ b/pkg/app/deploy.go
@@ -203,11 +203,15 @@ func (a *App) Deploy(ctx context.Context) error { //nolint:funlen
 
 	switch a.Type {
 	case TypeBootstrap:
-		return a.deployBootstrap(ctx)
+		err = a.deployBootstrap(ctx)
 	case TypeLegacy:
-		return a.deployLegacy(ctx)
+		err = a.deployLegacy(ctx)
+	default:
+		err = fmt.Errorf("unknown application type %s", a.Type)
+	}
+	if err != nil {
+		return err
 	}
 
-	// If this ever fires, there is an issue with *App.determineType.
-	return fmt.Errorf("unknown application type %s", a.Type)
+	return devenvutil.WaitForAllPodsToBeReady(ctx, a.k, a.log)
 }


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->
<!-- 
  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: This PR brings the new generic ready pod wait to `deploy-app`, this should help users, and automated scripts, get a better idea of when a devenv is ready post deploy-app command. It's not perfect, but it's about the best we can do in Kubernetes.

<!--- Block(jiraPrefix) --->
**JIRA ID**: DTSS-0
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:

<!--- Block(custom) -->
<!--- EndBlock(custom) -->
