### PR TITLE
feat: deploy vcluster-annotator to all loft devenvs

### DIFF
--- a/pkg/devenvutil/devenv.go
+++ b/pkg/devenvutil/devenv.go
@@ -84,9 +84,15 @@ type ListableType interface {
 }
 
 type DeleteObjectsObjects struct {
-	Type       runtime.Object
+	// Type is the type of object that should be deleted.
+	Type runtime.Object
+
+	// Namespaces is a list of namespaces that objects should be deleted in
 	Namespaces []string
-	Validator  func(obj *unstructured.Unstructured) (filter bool)
+
+	// Validator is a function that returns if an item should be filtered
+	// or not.
+	Validator func(obj *unstructured.Unstructured) (filter bool)
 }
 
 func DeleteObjects(ctx context.Context, log logrus.FieldLogger, k kubernetes.Interface, conf *rest.Config, opts DeleteObjectsObjects) error { //nolint:funlen


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

By deploying `vcluster-annotator` to all cloud devenvs we are easily able to make all pods be safe to evict via the cluster-autoscaler, enabling GKE to scale down (among other clusters).


<!--- Block(jiraPrefix) --->
**JIRA ID**: [DTSS-0]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
