### PR TITLE
feat: stop/start remote clusters

### DIFF
--- a/pkg/kubernetesruntime/kubernetesruntime.go
+++ b/pkg/kubernetesruntime/kubernetesruntime.go
@@ -81,6 +81,12 @@ type Runtime interface {
 	// Destroy destroys a kubernetes cluster from this runtime
 	Destroy(context.Context) error
 
+	// Stop stops (sleeps) a kubernetes cluster from this runtime
+	Stop(context.Context) error
+
+	// Start starts (awakens) a kubernetes cluster from this runtime
+	Start(context.Context) error
+
 	// PreCreate is ran before creating a kubernetes cluster, useful
 	// for implementing pre-requirements.
 	PreCreate(context.Context) error

--- a/pkg/kubernetesruntime/loft.go
+++ b/pkg/kubernetesruntime/loft.go
@@ -220,8 +220,28 @@ func (lr *LoftRuntime) Destroy(ctx context.Context) error {
 		return err
 	}
 
-	out, err := exec.CommandContext(ctx, loft, "delete", "vcluster", lr.clusterName).CombinedOutput()
+	out, err := exec.CommandContext(ctx, loft, "delete", "vcluster", "--delete-space", lr.clusterName).CombinedOutput()
 	return errors.Wrapf(err, "failed to delete loft vcluster: %s", out)
+}
+
+func (lr *LoftRuntime) Stop(ctx context.Context) error {
+	loft, err := lr.ensureLoft(lr.log)
+	if err != nil {
+		return err
+	}
+
+	out, err := exec.CommandContext(ctx, loft, "sleep", "vcluster-"+lr.clusterName).CombinedOutput()
+	return errors.Wrapf(err, "failed to put loft vcluster to sleep: %s", out)
+}
+
+func (lr *LoftRuntime) Start(ctx context.Context) error {
+	loft, err := lr.ensureLoft(lr.log)
+	if err != nil {
+		return err
+	}
+
+	out, err := exec.CommandContext(ctx, loft, "wakeup", "vcluster-"+lr.clusterName).CombinedOutput()
+	return errors.Wrapf(err, "failed to wakeup loft vcluster: %s", out)
 }
 
 func (lr *LoftRuntime) GetKubeConfig(ctx context.Context) (*api.Config, error) {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR adds support for `devenv stop` and `devenv start` to remote Kubernetes clusters, we also now cleanup loft spaces to prevent extra resources from being left over when a cluster is deleted.


<!--- Block(jiraPrefix) --->
**JIRA ID**: DTSS-0
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
