### PR TITLE
fix(context): show kind always except unprov

### DIFF
--- a/pkg/kubernetesruntime/kind.go
+++ b/pkg/kubernetesruntime/kind.go
@@ -219,8 +219,8 @@ func (kr *KindRuntime) GetKubeConfig(ctx context.Context) (*api.Config, error) {
 func (kr *KindRuntime) GetClusters(ctx context.Context) ([]*RuntimeCluster, error) {
 	curStatus := kr.Status(ctx).Status.Status
 
-	if curStatus == status.Unprovisioned || curStatus == status.Unknown {
-		// Only return a cluster if it's actively running
+	if curStatus == status.Unprovisioned {
+		// Only return a cluster if it's no unprovisioned
 		return []*RuntimeCluster{}, nil
 	}
 

--- a/pkg/kubernetesruntime/kind.go
+++ b/pkg/kubernetesruntime/kind.go
@@ -220,7 +220,7 @@ func (kr *KindRuntime) GetClusters(ctx context.Context) ([]*RuntimeCluster, erro
 	curStatus := kr.Status(ctx).Status.Status
 
 	if curStatus == status.Unprovisioned {
-		// Only return a cluster if it's no unprovisioned
+		// Only return a cluster if it's not unprovisioned
 		return []*RuntimeCluster{}, nil
 	}
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR fixes `devenv context` to show KinD always, except when it's unprovisioned to ensure that there is a decent UX for cases when it's stopped but undetectable.


<!--- Block(jiraPrefix) --->
**JIRA ID**: [DTSS-0]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
