### PR TITLE
fix: remove init func from alert package

### DIFF
--- a/internal/alert/alert.go
+++ b/internal/alert/alert.go
@@ -10,6 +10,6 @@ const alertTitle = "Kubernetes Developer Environment"
 // Alert is a best effort function that hooks into the operating system's alerting
 // mechanism to send the user a message.
 func Alert(message string) {
-	_ = beeep.Alert(alertTitle, message, "") //nolint:errcheck // Why: This is best effort, and may not be supported on all platforms. 
-	_ = beeep.Beep(beeep.DefaultFreq, 2000) //nolint:errcheck // Why: This is best effort, and may not be supported on all platforms.
+	_ = beeep.Alert(alertTitle, message, "") //nolint:errcheck // Why: This is best effort, and may not be supported on all platforms.
+	_ = beeep.Beep(beeep.DefaultFreq, 2000)  //nolint:errcheck // Why: This is best effort, and may not be supported on all platforms.
 }

--- a/internal/alert/alert.go
+++ b/internal/alert/alert.go
@@ -7,12 +7,9 @@ import "github.com/gen2brain/beeep"
 // alertTitle is the title given to all alerts (see the Alert function).
 const alertTitle = "Kubernetes Developer Environment"
 
-func init() { //nolint:gochecknoinits // Why: We're initializing beeep, this is OK.
-	_ = beeep.Beep(beeep.DefaultFreq, 2000) //nolint:errcheck // Why: This is best effort, and may not be supported on all platforms.
-}
-
 // Alert is a best effort function that hooks into the operating system's alerting
 // mechanism to send the user a message.
 func Alert(message string) {
-	_ = beeep.Alert(alertTitle, message, "") //nolint:errcheck // Why: This is best effort, and may not be supported on all platforms.
+	_ = beeep.Alert(alertTitle, message, "") //nolint:errcheck // Why: This is best effort, and may not be supported on all platforms. 
+	_ = beeep.Beep(beeep.DefaultFreq, 2000) //nolint:errcheck // Why: This is best effort, and may not be supported on all platforms.
 }


### PR DESCRIPTION

<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
* That function that was being called in it I thought was an initializer for the beeep package. It's not.



<!--- Block(jiraPrefix) --->
**JIRA ID**: XX-XX
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
