### PR TITLE
feat: auth-vault reauthenticates vault operator in devenv

### DIFF
--- a/cmd/devenv/auth-vault/auth.go
+++ b/cmd/devenv/auth-vault/auth.go
@@ -1,0 +1,96 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/getoutreach/devenv/internal/vault"
+	"github.com/getoutreach/devenv/pkg/cmdutil"
+	"github.com/getoutreach/devenv/pkg/config"
+	"github.com/getoutreach/devenv/pkg/devenvutil"
+	"github.com/getoutreach/devenv/pkg/kube"
+	"github.com/getoutreach/gobox/pkg/box"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+//nolint:gochecknoglobals
+var (
+	authVault = `
+		auth-vault ensures Vault operator has valid credentials for creating/updating secrets.
+	`
+	authVaultExample = `
+		# Reauthenticate Vault operator
+		devenv auth-vault
+	`
+)
+
+type Options struct {
+	log  logrus.FieldLogger
+	k    kubernetes.Interface
+	conf *rest.Config
+
+	App string
+}
+
+func NewOptions(log logrus.FieldLogger) (*Options, error) {
+	k, conf, err := kube.GetKubeClientWithConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create kubernetes client")
+	}
+
+	return &Options{
+		k:    k,
+		conf: conf,
+		log:  log,
+	}, nil
+}
+
+func NewCmdAuthVault(log logrus.FieldLogger) *cli.Command {
+	return &cli.Command{
+		Name:        "auth-vault",
+		Usage:       "Reauthenticate Vault operator",
+		Description: cmdutil.NewDescription(authVault, authVaultExample),
+		Flags:       []cli.Flag{},
+		Action: func(c *cli.Context) error {
+			if c.Args().Len() == 0 {
+				return fmt.Errorf("missing application")
+			}
+			o, err := NewOptions(log)
+			if err != nil {
+				return err
+			}
+
+			o.App = c.Args().First()
+			return o.Run(c.Context)
+		},
+	}
+}
+
+func (o *Options) Run(ctx context.Context) error {
+	b, err := box.LoadBox()
+	if err != nil {
+		return errors.Wrap(err, "failed to load box configuration")
+	}
+
+	conf, err := config.LoadConfig(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to load config")
+	}
+
+	_, err = devenvutil.EnsureDevenvRunning(ctx, conf, b)
+	if err != nil {
+		return err
+	}
+
+	if b.DeveloperEnvironmentConfig.VaultConfig.Enabled {
+		if err := vault.EnsureLoggedIn(ctx, o.log, b, o.k); err != nil {
+			return errors.Wrap(err, "failed to refresh vault authentication")
+		}
+	}
+
+	return nil
+}

--- a/cmd/devenv/auth-vault/auth.go
+++ b/cmd/devenv/auth-vault/auth.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/getoutreach/devenv/internal/vault"
 	"github.com/getoutreach/devenv/pkg/cmdutil"
@@ -56,15 +55,11 @@ func NewCmdAuthVault(log logrus.FieldLogger) *cli.Command {
 		Description: cmdutil.NewDescription(authVault, authVaultExample),
 		Flags:       []cli.Flag{},
 		Action: func(c *cli.Context) error {
-			if c.Args().Len() == 0 {
-				return fmt.Errorf("missing application")
-			}
 			o, err := NewOptions(log)
 			if err != nil {
 				return err
 			}
 
-			o.App = c.Args().First()
 			return o.Run(c.Context)
 		},
 	}

--- a/cmd/devenv/auth/auth.go
+++ b/cmd/devenv/auth/auth.go
@@ -1,0 +1,30 @@
+package auth
+
+import (
+	"github.com/getoutreach/devenv/pkg/cmdutil"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+)
+
+//nolint:gochecknoglobals
+var (
+	auth = `
+		Manage devenv auth state.
+	`
+	authExample = `
+		# Refresh Vault operator
+		devenv auth refresh
+	`
+)
+
+// NewCmdAuth returns a new instance of the auth command.
+func NewCmdAuth(log logrus.FieldLogger) *cli.Command {
+	return &cli.Command{
+		Name:        "auth",
+		Description: cmdutil.NewDescription(auth, authExample),
+		Flags:       []cli.Flag{},
+		Subcommands: []*cli.Command{
+			NewCmdAuthRefresh(log),
+		},
+	}
+}

--- a/cmd/devenv/auth/refresh.go
+++ b/cmd/devenv/auth/refresh.go
@@ -7,55 +7,48 @@ import (
 	"github.com/getoutreach/devenv/pkg/cmdutil"
 	"github.com/getoutreach/devenv/pkg/config"
 	"github.com/getoutreach/devenv/pkg/devenvutil"
-	"github.com/getoutreach/devenv/pkg/kube"
 	"github.com/getoutreach/gobox/pkg/box"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 //nolint:gochecknoglobals
 var (
-	authVault = `
-		auth-vault ensures Vault operator has valid credentials for creating/updating secrets.
+	refresh = `
+		Refresh ensures Vault operator has valid credentials for creating/updating secrets.
 	`
-	authVaultExample = `
+	refreshExample = `
 		# Reauthenticate Vault operator
-		devenv auth-vault
+		devenv auth refresh
 	`
 )
 
-type Options struct {
-	log  logrus.FieldLogger
-	k    kubernetes.Interface
-	conf *rest.Config
+// RefreshOptions the options for the auth refresh command.
+type RefreshOptions struct {
+	log logrus.FieldLogger
+	k   kubernetes.Interface
 
 	App string
 }
 
-func NewOptions(log logrus.FieldLogger) (*Options, error) {
-	k, conf, err := kube.GetKubeClientWithConfig()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create kubernetes client")
-	}
-
-	return &Options{
-		k:    k,
-		conf: conf,
-		log:  log,
+// NewRefreshOptions creates a new instance of the auth refresh options.
+func NewRefreshOptions(log logrus.FieldLogger) (*RefreshOptions, error) {
+	return &RefreshOptions{
+		log: log,
 	}, nil
 }
 
-func NewCmdAuthVault(log logrus.FieldLogger) *cli.Command {
+// NewCmdAuthRefresh returns a new instance of the auth refresh command.
+func NewCmdAuthRefresh(log logrus.FieldLogger) *cli.Command {
 	return &cli.Command{
-		Name:        "auth-vault",
-		Usage:       "Reauthenticate Vault operator",
-		Description: cmdutil.NewDescription(authVault, authVaultExample),
+		Name:        "refresh",
+		Usage:       "Refresh Vault token used by devenv vault operator",
+		Description: cmdutil.NewDescription(refresh, refreshExample),
 		Flags:       []cli.Flag{},
 		Action: func(c *cli.Context) error {
-			o, err := NewOptions(log)
+			o, err := NewRefreshOptions(log)
 			if err != nil {
 				return err
 			}
@@ -65,7 +58,8 @@ func NewCmdAuthVault(log logrus.FieldLogger) *cli.Command {
 	}
 }
 
-func (o *Options) Run(ctx context.Context) error {
+// Run executes the auth refresh command.
+func (o *RefreshOptions) Run(ctx context.Context) error {
 	b, err := box.LoadBox()
 	if err != nil {
 		return errors.Wrap(err, "failed to load box configuration")

--- a/cmd/devenv/devenv.go
+++ b/cmd/devenv/devenv.go
@@ -20,6 +20,7 @@ import (
 
 	// Place any extra imports for your startup code here
 	///Block(imports)
+	"github.com/getoutreach/devenv/cmd/devenv/auth-vault"
 	"github.com/getoutreach/devenv/cmd/devenv/completion"
 	cmdcontext "github.com/getoutreach/devenv/cmd/devenv/context"
 	deleteapp "github.com/getoutreach/devenv/cmd/devenv/delete-app"
@@ -98,6 +99,7 @@ func main() {
 	}
 	app.Commands = []*cli.Command{
 		///Block(commands)
+		auth.NewCmdAuthVault(log),
 		provision.NewCmdProvision(log),
 		deployapp.NewCmdDeployApp(log),
 		deleteapp.NewCmdDeleteApp(log),

--- a/cmd/devenv/devenv.go
+++ b/cmd/devenv/devenv.go
@@ -20,7 +20,7 @@ import (
 
 	// Place any extra imports for your startup code here
 	///Block(imports)
-	"github.com/getoutreach/devenv/cmd/devenv/auth-vault"
+	"github.com/getoutreach/devenv/cmd/devenv/auth"
 	"github.com/getoutreach/devenv/cmd/devenv/completion"
 	cmdcontext "github.com/getoutreach/devenv/cmd/devenv/context"
 	deleteapp "github.com/getoutreach/devenv/cmd/devenv/delete-app"
@@ -99,7 +99,7 @@ func main() {
 	}
 	app.Commands = []*cli.Command{
 		///Block(commands)
-		auth.NewCmdAuthVault(log),
+		auth.NewCmdAuth(log),
 		provision.NewCmdProvision(log),
 		deployapp.NewCmdDeployApp(log),
 		deleteapp.NewCmdDeleteApp(log),


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
When vault token in devenv expires, new secrets on deployment don't get created. There's no way to just refresh the token today. `deploy-app` does the trick, but it also applies manifests (in case of cloud devenv, without pushing docker image). This helps mitigate issue with `devspace deploy`.




<!--- Block(jiraPrefix) --->
**JIRA ID**: XX-XX
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
