### PR TITLE
fix: Pass kubernetes client to auth refresh

### DIFF
--- a/cmd/devenv/auth/refresh.go
+++ b/cmd/devenv/auth/refresh.go
@@ -7,6 +7,7 @@ import (
 	"github.com/getoutreach/devenv/pkg/cmdutil"
 	"github.com/getoutreach/devenv/pkg/config"
 	"github.com/getoutreach/devenv/pkg/devenvutil"
+	"github.com/getoutreach/devenv/pkg/kube"
 	"github.com/getoutreach/gobox/pkg/box"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -35,8 +36,14 @@ type RefreshOptions struct {
 
 // NewRefreshOptions creates a new instance of the auth refresh options.
 func NewRefreshOptions(log logrus.FieldLogger) (*RefreshOptions, error) {
+	k, _, err := kube.GetKubeClientWithConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create kubernetes client")
+	}
+
 	return &RefreshOptions{
 		log: log,
+		k:   k,
 	}, nil
 }
 

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -48,6 +48,8 @@ func EnsureLoggedIn(ctx context.Context, log logrus.FieldLogger, b *box.Config, 
 		if err2 != nil {
 			return err2
 		}
+	} else {
+		log.Warn("No Kubernetes client available, not refreshing Kubernetes environment")
 	}
 
 	return nil


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

It doesn't work if it can't update kubernetes.

<!--- Block(jiraPrefix) --->
**JIRA ID**: XX-XX
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
