### PR TITLE
fix(apps): dont swallow auth error

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -108,6 +108,9 @@ func NewApp(ctx context.Context, log logrus.FieldLogger, k kubernetes.Interface,
 	}
 	app.log = log.WithField("app.name", app.RepositoryName)
 
+	// IDEA: We probably need to detect the version first
+	// so we now which ref to check.
+	//
 	// Get the type first for validation checks later
 	if err := app.determineType(ctx); err != nil {
 		return nil, errors.Wrap(err, "determine repository name")
@@ -300,6 +303,10 @@ func (a *App) determineType(ctx context.Context) error {
 	gh := github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: string(token)},
 	)))
+
+	if _, _, err := gh.Repositories.Get(ctx, a.box.Org, a.RepositoryName); err != nil {
+		return errors.Wrap(err, "failed to check if repository exists")
+	}
 
 	if _, _, _, err = gh.Repositories.GetContents(ctx, a.box.Org, a.RepositoryName, "bootstrap.lock",
 		&github.RepositoryContentGetOptions{


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Don't swallow 404/auth errors when determining the application type. Originally we swallowed errors to detect the type, but when looking for an invalid repo or on invalid auth this would swallow that error and instead return a cryptic ref failure message.

<!--- Block(jiraPrefix) --->
**JIRA ID**: [DTSS-0]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
