### PR TITLE
fix: use apps deploy instead of deploy-app

### DIFF
--- a/cmd/devenv/apps/update/update.go
+++ b/cmd/devenv/apps/update/update.go
@@ -120,7 +120,7 @@ func (o *Options) Run(ctx context.Context) error {
 			}
 		}
 		if foundApp == nil {
-			return fmt.Errorf("Unknown app '%s', please use deploy-app to deploy it first", o.AppName)
+			return fmt.Errorf("Unknown app '%s', please use `devenv apps deploy` to deploy it first", o.AppName)
 		}
 
 		// only update the app provided

--- a/cmd/devenv/apps/update/update.go
+++ b/cmd/devenv/apps/update/update.go
@@ -120,7 +120,7 @@ func (o *Options) Run(ctx context.Context) error {
 			}
 		}
 		if foundApp == nil {
-			return fmt.Errorf("Unknown app '%s', please use `devenv apps deploy` to deploy it first", o.AppName)
+			return fmt.Errorf("Unknown app '%s', please use devenv apps deploy first", o.AppName)
 		}
 
 		// only update the app provided

--- a/cmd/devenv/snapshot/snapshot.go
+++ b/cmd/devenv/snapshot/snapshot.go
@@ -417,7 +417,7 @@ func (o *Options) generateSnapshot(ctx context.Context, s3c *s3.Client,
 		o.log.Info("Deploying applications into devenv")
 		for _, app := range t.DeployApps {
 			o.log.WithField("application", app).Info("Deploying application")
-			cmd := exec.CommandContext(ctx, os.Args[0], "--skip-update", "deploy-app", app) //nolint:gosec
+			cmd := exec.CommandContext(ctx, os.Args[0], "--skip-update", "apps", "deploy", app) //nolint:gosec
 			cmd.Stderr = os.Stderr
 			cmd.Stdout = os.Stdout
 			cmd.Stdin = os.Stdin
@@ -439,7 +439,7 @@ func (o *Options) generateSnapshot(ctx context.Context, s3c *s3.Client,
 		o.log.Info("Deploying applications into devenv")
 		for _, app := range t.PostDeployApps {
 			o.log.WithField("application", app).Info("Deploying application")
-			cmd := exec.CommandContext(ctx, os.Args[0], "--skip-update", "deploy-app", app) //nolint:gosec
+			cmd := exec.CommandContext(ctx, os.Args[0], "--skip-update", "apps", "deploy", app) //nolint:gosec
 			cmd.Stderr = os.Stderr
 			cmd.Stdout = os.Stdout
 			cmd.Stdin = os.Stdin

--- a/docs/interacting-with-services.md
+++ b/docs/interacting-with-services.md
@@ -27,8 +27,7 @@ To deploy a specific revision of a service, run `devenv apps deploy <appName@Com
 
 ### Deploying Local Changes
 
-To deploy your application into Kubernetes locally, run `devenv deploy-app --local .`. Press `y` when prompted
-to build a Docker image.
+To deploy your application into Kubernetes locally, run `devenv apps deploy .`.
 
 ## Updating Services
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -25,7 +25,7 @@ dev-environment has already started to be provisioned)_:
 devenv provision
 ```
 
-To deploy additional services, use the `--deploy-app $APP_NAME` flag, where `$APP_NAME` is the name
+To deploy additional services, use the `devenv apps deploy $APP_NAME` flag, where `$APP_NAME` is the name
 of your service's GitHub repository. Every [`bootstrap` (coming soon!)](https://github.com/getoutreach/bootstrap)-created
 service can be deployed into this environment without any extra configuration.
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
`devenv deploy-app` is deprecated and need to use `devenv apps run` instead 

<!--- Block(jiraPrefix) --->

## Jira ID
https://outreach-io.atlassian.net/browse/DTSS-1594

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
