### PR TITLE
fix: Use box config for image registry in legacy deployments.

### DIFF
--- a/pkg/app/common.go
+++ b/pkg/app/common.go
@@ -96,6 +96,16 @@ func (a *App) commandEnv(ctx context.Context) ([]string, error) {
 	return vars, nil
 }
 
+// commandEnvLegacyOverrides returns the environment variables that should be set for legacy (pre-devspace) commands
+func (a *App) commandEnvLegacyOverrides(ctx context.Context) ([]string, error) {
+	vars := []string{
+		fmt.Sprintf("DEVENV_DEPLOY_IMAGE_REGISTRY=%s", a.box.DeveloperEnvironmentConfig.ImageRegistry),
+		fmt.Sprintf("DEVENV_DEPLOY_DEV_IMAGE_REGISTRY=%s", a.box.DeveloperEnvironmentConfig.ImageRegistry),
+		fmt.Sprintf("DEVENV_DEPLOY_BOX_IMAGE_REGISTRY=%s", a.box.DeveloperEnvironmentConfig.ImageRegistry),
+	}
+	return vars, nil
+}
+
 // commandBuilderOptions contains options for creating exec.Cmd to run either a devspace or fallback command
 type commandBuilderOptions struct {
 	environmentVariabes []string

--- a/pkg/app/common.go
+++ b/pkg/app/common.go
@@ -97,13 +97,13 @@ func (a *App) commandEnv(ctx context.Context) ([]string, error) {
 }
 
 // commandEnvLegacyOverrides returns the environment variables that should be set for legacy (pre-devspace) commands
-func (a *App) commandEnvLegacyOverrides(ctx context.Context) ([]string, error) {
+func (a *App) commandEnvLegacyOverrides() []string {
 	vars := []string{
 		fmt.Sprintf("DEVENV_DEPLOY_IMAGE_REGISTRY=%s", a.box.DeveloperEnvironmentConfig.ImageRegistry),
 		fmt.Sprintf("DEVENV_DEPLOY_DEV_IMAGE_REGISTRY=%s", a.box.DeveloperEnvironmentConfig.ImageRegistry),
 		fmt.Sprintf("DEVENV_DEPLOY_BOX_IMAGE_REGISTRY=%s", a.box.DeveloperEnvironmentConfig.ImageRegistry),
 	}
-	return vars, nil
+	return vars
 }
 
 // commandBuilderOptions contains options for creating exec.Cmd to run either a devspace or fallback command

--- a/pkg/app/deploy.go
+++ b/pkg/app/deploy.go
@@ -54,8 +54,12 @@ func (a *App) deployLegacy(ctx context.Context) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	// If we can, we should add the variables
+	// If we can, we should add the deployment variables
 	if vars, err := a.commandEnv(ctx); err == nil {
+		cmd.Env = append(cmd.Env, vars...)
+	}
+	// And since pre-devspace certain features weren't supported, we need to overwrite some of the env vars
+	if vars, err := a.commandEnvLegacyOverrides(ctx); err == nil {
 		cmd.Env = append(cmd.Env, vars...)
 	}
 
@@ -89,8 +93,12 @@ func (a *App) deployBootstrap(ctx context.Context) error { //nolint:funlen
 		return errors.Wrap(err, "failed to create command")
 	}
 
-	// If we can, we should add the variables
+	// If we can, we should add the deployment variables
 	if vars, err := a.commandEnv(ctx); err == nil {
+		cmd.Env = append(cmd.Env, vars...)
+	}
+	// And since pre-devspace certain features weren't supported, we need to overwrite some of the env vars
+	if vars, err := a.commandEnvLegacyOverrides(ctx); err == nil {
 		cmd.Env = append(cmd.Env, vars...)
 	}
 

--- a/pkg/app/deploy.go
+++ b/pkg/app/deploy.go
@@ -59,9 +59,7 @@ func (a *App) deployLegacy(ctx context.Context) error {
 		cmd.Env = append(cmd.Env, vars...)
 	}
 	// And since pre-devspace certain features weren't supported, we need to overwrite some of the env vars
-	if vars, err := a.commandEnvLegacyOverrides(ctx); err == nil {
-		cmd.Env = append(cmd.Env, vars...)
-	}
+	cmd.Env = append(cmd.Env, a.commandEnvLegacyOverrides()...)
 
 	cmd.Env = append(cmd.Env, "DEPLOY_TO_DEV_VERSION="+a.Version)
 	return cmd.Run()
@@ -98,9 +96,7 @@ func (a *App) deployBootstrap(ctx context.Context) error { //nolint:funlen
 		cmd.Env = append(cmd.Env, vars...)
 	}
 	// And since pre-devspace certain features weren't supported, we need to overwrite some of the env vars
-	if vars, err := a.commandEnvLegacyOverrides(ctx); err == nil {
-		cmd.Env = append(cmd.Env, vars...)
-	}
+	cmd.Env = append(cmd.Env, a.commandEnvLegacyOverrides()...)
 
 	cmd.Env = append(cmd.Env, "DEPLOY_TO_DEV_VERSION="+a.Version)
 	if b, err := cmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

`build-jsonnet.sh` script in `devbase` recognizes the new env variables as it's reused between legacy and devspace deploys. Building docker images using `make docker-build` doesn't.



<!--- Block(jiraPrefix) --->

## Jira ID

[DTSS-1593]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DTSS-1593]: https://outreach-io.atlassian.net/browse/DTSS-1593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ