### PR TITLE
feat: Shim `kubectl` for child processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ _ := $(shell ./scripts/devbase.sh)
 
 include .bootstrap/root/Makefile
 
+LDFLAGS += -X k8s.io/component-base/version.gitMajor=1
+LDFLAGS += -X k8s.io/component-base/version.gitMinor=23
+LDFLAGS += -X k8s.io/component-base/version.gitVersion=v1.23.5
+LDFLAGS += -X k8s.io/component-base/version.gitCommit=272114478c66b8250050dd68d4719c46c2ab2088
+
 ###Block(targets)
 .PHONY: e2e-override
 e2e-override:

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ _ := $(shell ./scripts/devbase.sh)
 
 include .bootstrap/root/Makefile
 
+###Block(targets)
 LDFLAGS += -X k8s.io/component-base/version.gitMajor=1
 LDFLAGS += -X k8s.io/component-base/version.gitMinor=23
 LDFLAGS += -X k8s.io/component-base/version.gitVersion=v1.23.5
 LDFLAGS += -X k8s.io/component-base/version.gitCommit=272114478c66b8250050dd68d4719c46c2ab2088
 
-###Block(targets)
 .PHONY: e2e-override
 e2e-override:
 	TEST_OUTPUT_FORMAT=standard-verbose TEST_FLAGS=-v TEST_TAGS=or_e2e ./scripts/shell-wrapper.sh test.sh

--- a/cmd/devenv/devenv.go
+++ b/cmd/devenv/devenv.go
@@ -36,6 +36,7 @@ import (
 	"github.com/getoutreach/devenv/cmd/devenv/status"
 	"github.com/getoutreach/devenv/cmd/devenv/stop"
 	"github.com/getoutreach/devenv/cmd/devenv/tunnel"
+	"github.com/getoutreach/devenv/internal/shim"
 	"github.com/getoutreach/devenv/pkg/cmdutil"
 	///EndBlock(imports)
 )
@@ -91,6 +92,17 @@ func main() {
 			err = os.MkdirAll(filepath.Join(homeDir, ".local", "dev-environment"), 0o755)
 			if err != nil {
 				return err
+			}
+
+			binPath, err := os.Executable()
+			if err != nil {
+				return errors.Wrap(err, "failed to get devenv executable path")
+			}
+			os.Setenv("DEVENV_BIN", binPath)
+
+			err = shim.AddKubectl()
+			if err != nil {
+				return errors.Wrap(err, "failed to create kubectl shim")
 			}
 
 			_, err = box.EnsureBoxWithOptions(ctx, box.WithLogger(log), box.WithMinVersion(2))

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	// Ensure that the versions here are always the same
 	// and that the replace directives are updated to match.
 	// Current version: v0.23.1
+	// Makefile needs to be updated as well.
 	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
 	k8s.io/cli-runtime v0.23.1

--- a/internal/shim/kubectl.embed
+++ b/internal/shim/kubectl.embed
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# We want to use the devenv that triggered this command. 
+# devenv sets the environment variable $DEVENV_BIN with path to itself.
+DEVENV_BIN="${DEVENV_BIN:-devenv}"
+
+"$DEVENV_BIN" --skip-update kubectl "$@"

--- a/internal/shim/kubectl.go
+++ b/internal/shim/kubectl.go
@@ -1,0 +1,64 @@
+// Copyright 2022 Outreach Corporation. All Rights Reserved.
+
+package shim
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+//go:embed kubectl.embed
+var kubectlScript []byte
+
+// AddKubectl creates a kubectl shell script in $HOME/.local/dev-environment/bin. This script executes
+//
+//		devenv --skip-update kubectl "$@"
+//
+// The function also adds the script to $PATH so it's picked by child processes.
+func AddKubectl(opts ...func(*Options)) error {
+	o := &Options{}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	devenvShimDir := o.dir
+	if devenvShimDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return errors.Wrap(err, "failed get $HOME dir path")
+		}
+
+		devenvShimDir = filepath.Join(home, ".local", "dev-environment", "bin")
+		err = os.MkdirAll(devenvShimDir, 0o755)
+		if err != nil {
+			return errors.Wrap(err, "failed to create $HOME/.local/dev-environment/bin dir")
+		}
+	}
+
+	kubectlPath := filepath.Join(devenvShimDir, "kubectl")
+	if _, err := os.Stat(kubectlPath); os.IsNotExist(err) {
+		f, err := os.OpenFile(kubectlPath, os.O_CREATE|os.O_WRONLY, 0o744)
+		if err != nil {
+			return errors.Wrapf(err, "failed to open file %s", kubectlPath)
+		}
+		defer f.Close()
+
+		_, err = f.Write(kubectlScript)
+		if err != nil {
+			return errors.Wrapf(err, "failed to write to file %s", kubectlPath)
+		}
+	} else if err != nil {
+		return errors.Wrapf(err, "failed to check if file %s exists", kubectlPath)
+	}
+
+	if err := os.Setenv("PATH", fmt.Sprintf("%s:%s", devenvShimDir, os.Getenv("PATH"))); err != nil {
+		return errors.Wrap(err, "failed to add $HOME/.local/dev-environment/bin to $PATH")
+	}
+
+	return nil
+}

--- a/internal/shim/kubectl_test.go
+++ b/internal/shim/kubectl_test.go
@@ -1,0 +1,23 @@
+// Copyright 2022 Outreach Corporation. All Rights Reserved.
+
+package shim
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestAddKubectl(t *testing.T) {
+	tempDir := t.TempDir()
+
+	err := AddKubectl(WithShimDir(tempDir))
+	assert.NilError(t, err)
+
+	p, err := exec.LookPath("kubectl")
+	assert.NilError(t, err)
+
+	assert.Assert(t, p == filepath.Join(tempDir, "kubectl"))
+}

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -1,0 +1,14 @@
+// Copyright 2022 Outreach Corporation. All Rights Reserved.
+
+// Package shim is used for creating devenv specific command replacements.
+package shim
+
+type Options struct {
+	dir string
+}
+
+func WithShimDir(dir string) func(*Options) {
+	return func(opts *Options) {
+		opts.dir = dir
+	}
+}

--- a/internal/shim/shim.go
+++ b/internal/shim/shim.go
@@ -3,11 +3,23 @@
 // Package shim is used for creating devenv specific command replacements.
 package shim
 
+// Option functions set options for
+type Option func(*Options)
+
+// Options contain shim configuration
 type Options struct {
 	dir string
 }
 
-func WithShimDir(dir string) func(*Options) {
+// apply uses Option funcs to set Options values
+func (o *Options) apply(opts []Option) {
+	for _, opt := range opts {
+		opt(o)
+	}
+}
+
+// WithShimDir set shim directory option
+func WithShimDir(dir string) Option {
 	return func(opts *Options) {
 		opts.dir = dir
 	}

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -145,5 +145,5 @@ func (a *App) RunStop(ctx context.Context) error {
 		return errors.Wrap(err, "failed to stop dev mode for the application")
 	}
 
-	return a.appsClient.Set(ctx, &apps.App{Name: a.RepositoryName, Version: a.Version})
+	return nil
 }


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

User machine `kubectl`, devenv Kubernetes, and devenv `kubectl` can be incompatible. This forces use of fixed, embedded `kubectl` by devenv and child processes it spawns.

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
