### PR TITLE
fix: include unready pods in error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,10 @@ require (
 	k8s.io/kubectl v0.23.5
 )
 
-require github.com/docker/go-connections v0.4.0
+require (
+	github.com/davecgh/go-spew v1.1.1
+	github.com/docker/go-connections v0.4.0
+)
 
 require (
 	cloud.google.com/go/compute v0.1.0 // indirect
@@ -97,7 +100,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd // indirect
 	github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect

--- a/pkg/devenvutil/devenv.go
+++ b/pkg/devenvutil/devenv.go
@@ -241,14 +241,12 @@ func WaitForAllPodsToBeReady(ctx context.Context, k kubernetes.Interface, log lo
 
 		async.Sleep(ctx, 30*time.Second)
 	}
-
 	if ctx.Err() != nil {
-		// Write out a bit more detailed info on the prior to exit
-		log.WithError(err).WithField("pods", PodsStateInfo(unreadyPods)).
-			Info("Waiting for pods to be ready timed out")
+		return fmt.Errorf("timed out waiting for pods to be ready: %v", PodsStateInfo(unreadyPods))
 	}
 
-	return ctx.Err()
+	// All pods were ready, so no error
+	return nil
 }
 
 // PodsStateInfo returns a string per pod with the state

--- a/pkg/devenvutil/devenv.go
+++ b/pkg/devenvutil/devenv.go
@@ -2,10 +2,12 @@ package devenvutil
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/getoutreach/devenv/cmd/devenv/status"
 	"github.com/getoutreach/devenv/pkg/config"
 	"github.com/getoutreach/devenv/pkg/kubernetesruntime"
@@ -210,6 +212,7 @@ func FindUnreadyPods(ctx context.Context, k kubernetes.Interface) ([]string, []*
 			continue
 		}
 
+		unreadyPods = append(unreadyPods, po)
 		unreadyPodNames = append(unreadyPodNames, po.Namespace+"/"+po.Name)
 	}
 
@@ -226,23 +229,28 @@ func WaitForAllPodsToBeReady(ctx context.Context, k kubernetes.Interface, log lo
 	ctx, cancel := context.WithTimeout(ctx, time.Minute*20)
 	defer cancel()
 
-	var unreadyPodNames []string
 	var unreadyPods []*corev1.Pod
 	var err error
 	for ctx.Err() == nil {
-		unreadyPodNames, unreadyPods, err = FindUnreadyPods(ctx, k)
+		_, unreadyPods, err = FindUnreadyPods(ctx, k)
 		if err == nil {
 			log.Info("All pods were ready")
 			break
 		}
 
-		log.WithError(err).WithField("pods", unreadyPodNames).
+		log.WithError(err).WithField("pods", PodsStateInfo(unreadyPods)).
 			Info("Waiting for pods to be ready")
 
 		async.Sleep(ctx, 30*time.Second)
 	}
 	if ctx.Err() != nil {
-		return fmt.Errorf("timed out waiting for pods to be ready: %v", PodsStateInfo(unreadyPods))
+		stateInfo := PodsStateInfo(unreadyPods)
+		b, err := json.Marshal(stateInfo)
+		if err != nil {
+			// If we couldn't marshal it, use spew to try to get a string
+			b = []byte(spew.Sdump(stateInfo))
+		}
+		return fmt.Errorf("timed out waiting for pods to be ready: %s", b)
 	}
 
 	// All pods were ready, so no error
@@ -252,8 +260,8 @@ func WaitForAllPodsToBeReady(ctx context.Context, k kubernetes.Interface, log lo
 // PodsStateInfo returns a string per pod with the state
 func PodsStateInfo(pods []*corev1.Pod) map[string]interface{} {
 	podDetails := map[string]interface{}{}
-	for _, podValue := range pods {
-		podDetails[podValue.Name] = PodStateInfo(podValue)
+	for _, p := range pods {
+		podDetails[p.Name] = PodStateInfo(p)
 	}
 	return podDetails
 }


### PR DESCRIPTION
**What this PR does**: This PR updates the error message to include the unready pods instead of "context deadline exceeded". This has no real impact on the UX but allows our telemetry to track the unready pods.

Future improvements to make this more indexable should be made, this is done quickly for debugging reasons.