### PR TITLE
fix(provision): wait for restic init containers to finish

### DIFF
--- a/cmd/devenv/provision/prepare.go
+++ b/cmd/devenv/provision/prepare.go
@@ -40,7 +40,7 @@ func (o *Options) deployStage(ctx context.Context, stage string) error { //nolin
 
 		attempts := 0
 		for ctx.Err() == nil {
-			if attempts > 3 {
+			if attempts > 10 {
 				return fmt.Errorf("ran out of attempts")
 			}
 
@@ -60,7 +60,7 @@ func (o *Options) deployStage(ctx context.Context, stage string) error { //nolin
 			attempts++
 			o.log.WithError(err).Warn("Failed to apply manifests, retrying ...")
 
-			async.Sleep(ctx, time.Second*2)
+			async.Sleep(ctx, time.Second*5)
 		}
 		if ctx.Err() != nil {
 			return ctx.Err()

--- a/cmd/devenv/provision/provision.go
+++ b/cmd/devenv/provision/provision.go
@@ -285,16 +285,6 @@ func (o *Options) snapshotRestore(ctx context.Context) error { //nolint:funlen,g
 
 	// Wait for Velero to load the backup
 	o.log.Info("Creating snapshot storage CRD")
-
-	// HACK: vcluster currently requires that we map storage classes. This will be
-	// removed soon.
-	if o.KubernetesRuntime.GetConfig().Type == kubernetesruntime.RuntimeTypeRemote {
-		o.log.Info("Creating snapshot storage class map")
-		if err := o.createStorageClassMap(ctx); err != nil {
-			return errors.Wrap(err, "failed to create storage class map")
-		}
-	}
-
 	err = devenvutil.Backoff(ctx, 10*time.Second, 10, func() error {
 		err2 := m.CreateBackupStorage(ctx, "devenv", snapshotLocalBucket)
 		if err2 != nil && !kerrors.IsAlreadyExists(err2) {
@@ -405,25 +395,6 @@ func (o *Options) snapshotRestore(ctx context.Context) error { //nolint:funlen,g
 	}
 
 	return devenvutil.WaitForAllPodsToBeReady(ctx, o.k, o.log)
-}
-
-// createStorageClassMap maps standard to premium-rwo. This is required for GKE
-// to function properly with vcluster at the moment.
-func (o *Options) createStorageClassMap(ctx context.Context) error {
-	_, err := o.k.CoreV1().ConfigMaps("velero").Create(ctx, &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "change-storage-class-config",
-			Labels: map[string]string{
-				"velero.io/plugin-config":        "",
-				"velero.io/change-storage-class": "RestoreItemAction",
-			},
-		},
-		Data: map[string]string{
-			// Remap to a CSI driver in GKE.
-			"standard": "premium-rwo",
-		},
-	}, metav1.CreateOptions{})
-	return err
 }
 
 // findIncompleteResticRestores finds all restic restores that are in progress and returns them

--- a/pkg/kube/logs.go
+++ b/pkg/kube/logs.go
@@ -95,6 +95,10 @@ func StreamJobLogs(ctx context.Context, k kubernetes.Interface,
 		io.Copy(w, r) //nolint:errcheck // Why: OK not returning error here
 		r.Close()     //nolint:errcheck // Why: best effort
 
+		// HACK: Naive attempt at giving the job a few seconds to update it's status
+		// after a run. Don't really know a better way of doing this right now.
+		async.Sleep(ctx, time.Second*5)
+
 		// check success to prevent needing to wait later
 		if ready, err := JobSucceeded(ctx, k, name, namespace); err != nil {
 			return errors.Wrap(err, "snapshot stage job failed")


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

This PR changes the restic init container deletion code to wait for the pods to finish instead of immediately deleting them. There's some cases where deleting them can result in a bad state instead of waiting. This highlights issues with stuff (such as the CSI migration issues we hit with Velero on GKE) instead of masking it as problems with the underlying cluster (such as pods getting stuck in terminating forever). There's also a few small UX changes in this PR

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
