### PR TITLE
feat: cleanup velero namespace

### DIFF
--- a/cmd/devenv/provision/provision.go
+++ b/cmd/devenv/provision/provision.go
@@ -41,15 +41,12 @@ import (
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/factory"
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/renew"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kruntime "k8s.io/apimachinery/pkg/runtime"
 
 	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 )
@@ -310,70 +307,20 @@ func (o *Options) snapshotRestore(ctx context.Context) error { //nolint:funlen,g
 		}
 	}
 
-	// Sometimes, if we don't preemptively delete all restic-wait containing pods
-	// we can end up with a restic-wait attempting to run again, which results
-	// in the pod being blocked. This appears to happen whenever a pod is "restarted".
-	// Deleting all of these pods prevents that from happening as the restic-wait pod is
-	// removed by velero's admission controller.
 	o.log.Info("Waiting for restic restores to finish")
 	if err := o.waitForResticRestores(ctx); err != nil {
 		return errors.Wrap(err, "failed to wait for restic restores to complete")
 	}
 
 	o.log.Info("Cleaning up snapshot restore artifacts")
-	err = devenvutil.DeleteObjects(ctx, o.log, o.k, o.r, devenvutil.DeleteObjectsObjects{
-		Type: &corev1.Namespace{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Namespace",
-				APIVersion: corev1.SchemeGroupVersion.Identifier(),
-			},
-		},
-		Validator: func(obj *unstructured.Unstructured) bool {
-			var daemonset *corev1.Namespace
-			if err := kruntime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &daemonset); err != nil {
-				return true
-			}
 
-			if daemonset.Name == "velero" {
-				return false
-			}
-
-			return true
-		},
-	})
-	if err != nil {
-		return errors.Wrap(err, "failed to cleanup namespaces")
+	// After we restore the snapshot we no longer need the velero resource. They can also prevent auto scaling in loft.
+	if err := cmdutil.RunKubernetesCommand(ctx, "", false, "kubectl", "delete", "helmchart", "-n", "kube-system", "velero"); err != nil {
+		return errors.Wrap(err, "failed to cleanup velero helm chart")
 	}
+	o.log.Info("Deleted velero helmchart")
 
-	err = devenvutil.DeleteObjects(ctx, o.log, o.k, o.r, devenvutil.DeleteObjectsObjects{
-		Type: &corev1.Pod{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Pod",
-				APIVersion: corev1.SchemeGroupVersion.Identifier(),
-			},
-		},
-		Validator: func(obj *unstructured.Unstructured) bool {
-			var pod *corev1.Pod
-			if err := kruntime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &pod); err != nil {
-				return true
-			}
-
-			for i := range pod.Spec.InitContainers {
-				cont := &pod.Spec.InitContainers[i]
-				if cont.Name == "restic-wait" {
-					return false
-				}
-			}
-
-			return true
-		},
-	})
-	if err != nil {
-		return errors.Wrap(err, "failed to cleanup statefulset pods")
-	}
-
-	err = o.runProvisionScripts(ctx)
-	if err != nil {
+	if err := o.runProvisionScripts(ctx); err != nil {
 		return errors.Wrap(err, "failed to run provision.d scripts")
 	}
 

--- a/pkg/devenvutil/devenv.go
+++ b/pkg/devenvutil/devenv.go
@@ -165,7 +165,9 @@ func DeleteObjects(ctx context.Context, log logrus.FieldLogger,
 		log.WithField("key", fmt.Sprintf("%s/%s", unstruct.GetNamespace(),
 			unstruct.GetName())).Infof("deleting %s", mapping.Resource.GroupResource().String())
 		namespacedDr := dyn.Resource(mapping.Resource).Namespace(unstruct.GetNamespace())
-		err := namespacedDr.Delete(ctx, unstruct.GetName(), metav1.DeleteOptions{}) //nolint:govet // Why: We're OK shadowing err
+		propagationPolicy := metav1.DeletePropagationForeground
+		err := namespacedDr.Delete( //nolint:govet // Why: We're OK shadowing err
+			ctx, unstruct.GetName(), metav1.DeleteOptions{PropagationPolicy: &propagationPolicy})
 		return errors.Wrap(trace.SetCallStatus(ctx, err), "failed to delete object"), nil
 	})
 	return err


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

Cleans up the velero namespace after snapshot restore. This should reduce resource use and hopefully allow the loft clusters to scale.

<!--- Block(jiraPrefix) --->

## Jira ID

[DTSS-1724]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DTSS-1724]: https://outreach-io.atlassian.net/browse/DTSS-1724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ